### PR TITLE
improve: postphone config guard into each command

### DIFF
--- a/src/commands/note.ts
+++ b/src/commands/note.ts
@@ -2,7 +2,7 @@
 
 import { Next } from '.';
 import { Command, TelegramUpdate } from '../types';
-import { Config } from '../utils/config';
+import { Config, newGithubScret } from '../utils/config';
 import { addContentToGitHubFile } from '../utils/github';
 import { sendTelegramMessage, sendTelegramReaction } from '../utils/telegram';
 
@@ -20,16 +20,18 @@ const noteCommand: Command = {
 		chatId: number,
 		messageText: string,
 		telegramApiUrl: string,
-		env: Config,
+		cfg: Config,
 		update: TelegramUpdate
 	) {
 		if (messageText === '') {
 			return new Response('OK', { status: 200 });
 		}
 		try {
-			// Attempt to add content to the GitHub file
-			await addContentToGitHubFile(messageText, env);
+			cfg.github = await newGithubScret(cfg.KV_BINDING);
+			guardEmpty(cfg.githubToken, 'GITHUB_TOKEN', 'env');
 
+			// Attempt to add content to the GitHub file
+			await addContentToGitHubFile(messageText, cfg);
 			const messageId = update.message?.message_id;
 			if (messageId === undefined) {
 				throw new Error('Message ID is undefined, cannot send reaction');
@@ -50,3 +52,7 @@ const noteCommand: Command = {
 };
 
 export default noteCommand;
+function guardEmpty(githubToken: string, arg1: string, arg2: string) {
+	throw new Error('Function not implemented.');
+}
+

--- a/src/commands/stock.ts
+++ b/src/commands/stock.ts
@@ -23,9 +23,10 @@ export const stockCommand: Command = {
 		chatId: number,
 		messageText: string,
 		telegramApiUrl: string,
-		env: Config
+		cfg: Config
 	) {
-		const shareList = messageText === '' ? env.stockSymbols : messageText;
+		guardEmpty(cfg.fmpAPIKey, 'FMP_API_KEY', 'env');
+		const shareList = messageText === '' ? cfg.stockSymbols : messageText;
 		const symbolsToFetch = shareList
 			.split(';')
 			.map((s) => s.trim().toUpperCase())
@@ -46,7 +47,7 @@ export const stockCommand: Command = {
 			// Loop through each symbol and fetch its data
 			for (const symbol of symbolsToFetch) {
 				try {
-					const quote = await getStockQuote(env, symbol);
+					const quote = await getStockQuote(cfg, symbol);
 					if (quote) {
 						fetchedQuotes.push(quote);
 					} else {
@@ -129,3 +130,7 @@ const stockSubAddCommand: Command = {
 		return new Response('OK', { status: 200 });
 	},
 };
+function guardEmpty(fmpAPIKey: string, arg1: string, arg2: string) {
+	throw new Error('Function not implemented.');
+}
+

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -18,16 +18,18 @@ export interface Secrets {
  * This interface is used to ensure that all required environment variables are present and correctly typed.
  */
 export interface Config extends Secrets {
+	github: GithubConfig | undefined;
 	allowedUserId: number;
+	stockSymbols: string;
+	KV_BINDING: KVNamespace;
+}
+
+export interface GithubConfig {
 	githubRepoOwner: string;
 	githubRepoName: string;
 	githubFilePath: string;
 	githubCommitMessage: string;
 	githubBranchName: string;
-
-	stockSymbols: string;
-
-	KV_BINDING: KVNamespace;
 }
 
 /**
@@ -56,30 +58,18 @@ export async function initConfig(env: Env): Promise<Config> {
 		throw new Error('ALLOWED_USER_ID must be a valid number');
 	}
 
-	const githubRepoOwner = await kv.get('GITHUB_REPO_OWNER');
-	const githubRepoName = await kv.get('GITHUB_REPO_NAME');
-	const githubFilePath = await kv.get('GITHUB_FILE_PATH');
-	const githubCommitMessage = await kv.get('GITHUB_COMMIT_MESSAGE');
-	const githubBranchName = await kv.get('GITHUB_BRANCH_NAME');
+
 	const stockSymbols = await kv.get('STOCK_SYMBOLS');
 	const symbol = stockSymbols === null ? '' : stockSymbols;
 
-	guardEmpty(githubRepoOwner, 'GITHUB_REPO_OWNER', 'kv namespace');
-	guardEmpty(githubRepoName, 'GITHUB_REPO_NAME', 'kv namespace');
-	guardEmpty(githubFilePath, 'GITHUB_FILE_PATH', 'kv namespace');
-	guardEmpty(githubCommitMessage, 'GITHUB_COMMIT_MESSAGE', 'kv namespace');
-	guardEmpty(githubBranchName, 'GITHUB_BRANCH_NAME', 'kv namespace');
+
 	guardEmpty(stockSymbols, 'STOCK_SYMBOLS', 'kv namespace');
 
 	return {
 		...secrets,
+		github: undefined,
 		KV_BINDING: kv,
 		allowedUserId: parseInt(allowedUserId, 10),
-		githubRepoOwner: githubRepoOwner,
-		githubRepoName: githubRepoName,
-		githubFilePath: githubFilePath,
-		githubCommitMessage: githubCommitMessage,
-		githubBranchName: githubBranchName,
 		stockSymbols: symbol,
 	};
 }
@@ -94,12 +84,30 @@ export async function initConfig(env: Env): Promise<Config> {
 function newSecret(env: Env): Secrets {
 	guardEmpty(env.TELEGRAM_BOT_TOKEN, 'TELEGRAM_BOT_TOKEN', 'env');
 	guardEmpty(env.TELEGRAM_SECRET_TOKEN, 'TELEGRAM_SECRET_TOKEN', 'env');
-	guardEmpty(env.GITHUB_TOKEN, 'GITHUB_TOKEN', 'env');
-	guardEmpty(env.FMP_API_KEY, 'FMP_API_KEY', 'env');
 	return {
 		telegramBotToken: env.TELEGRAM_BOT_TOKEN,
 		telegramSecretToken: env.TELEGRAM_SECRET_TOKEN,
 		githubToken: env.GITHUB_TOKEN,
 		fmpAPIKey: env.FMP_API_KEY,
 	};
+}
+
+export async function newGithubScret(kv: KVNamespace): Promise<GithubConfig> {
+	const githubRepoOwner = await kv.get('GITHUB_REPO_OWNER');
+	const githubRepoName = await kv.get('GITHUB_REPO_NAME');
+	const githubFilePath = await kv.get('GITHUB_FILE_PATH');
+	const githubCommitMessage = await kv.get('GITHUB_COMMIT_MESSAGE');
+	const githubBranchName = await kv.get('GITHUB_BRANCH_NAME');
+	guardEmpty(githubRepoOwner, 'GITHUB_REPO_OWNER', 'kv namespace');
+	guardEmpty(githubRepoName, 'GITHUB_REPO_NAME', 'kv namespace');
+	guardEmpty(githubFilePath, 'GITHUB_FILE_PATH', 'kv namespace');
+	guardEmpty(githubCommitMessage, 'GITHUB_COMMIT_MESSAGE', 'kv namespace');
+	guardEmpty(githubBranchName, 'GITHUB_BRANCH_NAME', 'kv namespace');
+	return {
+		githubRepoOwner: githubRepoOwner,
+		githubRepoName: githubRepoName,
+		githubFilePath: githubFilePath,
+		githubCommitMessage: githubCommitMessage,
+		githubBranchName: githubBranchName,
+	}
 }

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -218,22 +218,23 @@ export function processFile(
  * Adds new content to the specified GitHub file, processing it based on date sections.
  * This is the main function that orchestrates the GitHub API calls and file processing.
  * @param {string} newContent - The content to add to the file.
- * @param {Config} env - The validated environment variables.
+ * @param {Config} cfg - The validated environment variables.
  * @returns {Promise<void>}
  * @throws {Error} If any step of the process fails.
  */
 export async function addContentToGitHubFile(
 	newContent: string,
-	env: Config
+	cfg: Config
 ): Promise<void> {
+
 	const {
 		githubRepoOwner,
 		githubRepoName,
 		githubFilePath,
 		githubCommitMessage,
 		githubBranchName,
-		githubToken,
-	} = env;
+	} = cfg.github!;
+	const githubToken=cfg.githubToken;
 
 	// Create the Octokit client once
 	const githubClient = createGitHubClient(githubToken);


### PR DESCRIPTION
Previously, if some of configuration items are missing, the whole service won't work. For example, people wants to use the stock feature without any github changes, but the code requires them to set them up otherwise service failed.

This commit relaxes this constrain, and move the guard into each command. Telgeram token and secret are still check before any command.