### PR TITLE
feature(poe): authentication check and add gemini support

### DIFF
--- a/src/commands/llm.ts
+++ b/src/commands/llm.ts
@@ -1,4 +1,4 @@
-import { ChatGPTRequest, GPT_4O_MINI, OpenAIClient } from '../utils/gpt';
+import { ChatGPTRequest, GEMINI_20_FLASH, LLMClient } from '../utils/gpt';
 import { Command, CommandRequest } from '../types';
 import { Registerable } from '../utils/registry';
 import { guardEmpty } from '../utils/config';
@@ -13,9 +13,9 @@ export class LlmCommand implements Command, Registerable {
 		const { trimedText: messageText } = req;
 		const cfg = this.cmd.config();
 		guardEmpty(cfg.openaiApiKey, 'OPEN_AI_API_KEY', 'env');
-		const openaiClient = new OpenAIClient(cfg.openaiApiKey);
+		const openaiClient = new LLMClient(cfg.openaiApiKey, cfg.poeApiKey);
 		const gptRequest: ChatGPTRequest = {
-			model: cfg.gptModel || GPT_4O_MINI,
+			model: cfg.gptModel || GEMINI_20_FLASH,
 			messages: [{ role: 'user', content: messageText }],
 		};
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ export interface TypedEnv {
 	GITHUB_TOKEN: string; // Your GitHub Personal Access Token
 	FMP_API_KEY: string;
 	OPEN_AI_API_KEY: string; // OpenAI API key for GPT commands
+	POE_API_KEY: string; // Poe.com key for GPT commands
+	POE_BOT_ACCESS_KEY: string;
 	KV_BINDING: KVNamespace; // Cloudflare Workers KV namespace binding
 	WEBSITE_BUCKET: R2Bucket; // R2 bucket for static website hosting
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -10,6 +10,8 @@ export interface Secrets {
 	githubToken: string;
 	fmpAPIKey: string;
 	openaiApiKey: string;
+	poeApiKey: string;
+	poeBotAccessToken: string;
 }
 
 /**
@@ -114,6 +116,8 @@ function newSecret(env: TypedEnv): Secrets {
 		githubToken: env.GITHUB_TOKEN,
 		fmpAPIKey: env.FMP_API_KEY,
 		openaiApiKey: env.OPEN_AI_API_KEY,
+		poeApiKey: env.POE_API_KEY,
+		poeBotAccessToken: env.POE_BOT_ACCESS_KEY,
 	};
 }
 


### PR DESCRIPTION
This commit adds authentication to ensure only requests come from poe platform will be served; the permession of the poe bot will be managed in platform side.

It also adds the gemini-2.0-flash as the default model for the poe bot, now it could serve basic queries.

The context maybe not be maintained well now, and will be done in the future.